### PR TITLE
dynamic objectstore password

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,8 @@
 VERSION=2.0
 AUTHURL=https://identity.stack.cloudvps.com/v2.0
 USER=extern_dataservices
-PASSWORD= **Use export OBJECTSTORE_PASSWORD=###########**
+TENANT_PASSWORD_NAME=EXTERN_DATASERVICES_PASSWORD
+PASSWORD= **Use export EXTERN_DATASERVICES_PASSWORD=###########**
 TENANT_NAME=extern_dataservices
 TENANT_ID=356c76835e424b968ed6d654c51204f0
 REGION_NAME=NL

--- a/src/extract/download_from_objectstore.py
+++ b/src/extract/download_from_objectstore.py
@@ -100,7 +100,10 @@ def parser():
     Download files from the objectstore:
     ``download_from_objectstore config.ini objectstore aanvalsplan_schoon/crow,aanvalsplan_schoon/mora data``
 
-    Use ``export OBJECTSTORE_PASSWORD=**********`` to add the password to your environment before running this command script.
+    Choose a PASSWORD_NAME to name the objectstore password. Add this to the config.ini file:
+    ``TENANT_PASSWORD_NAME=PASSWORD_NAME``
+
+    Use ``export PASSWORD_NAME=**********`` to add the password to your environment before running this command script.
     """
 
     parser = argparse.ArgumentParser(

--- a/src/helpers/connections.py
+++ b/src/helpers/connections.py
@@ -125,16 +125,18 @@ def objectstore_connection(config_full_path, config_name, print_config_vars=None
         An objectstore connection session.
       """
 
-    assert os.environ['OBJECTSTORE_PASSWORD']
-
     config = get_config(config_full_path)
+
+    tenant_password_name = config.get(config_name, 'TENANT_PASSWORD_NAME')
+
+    assert os.environ[tenant_password_name]
 
     if print_config_vars:
          logger.info('config variables.. :{}'.format(OBJECTSTORE))
 
     conn = Connection(authurl=config.get(config_name, 'AUTHURL'),
                       user=config.get(config_name, 'USER'),
-                      key=os.environ['OBJECTSTORE_PASSWORD'],
+                      key=os.environ[tenant_password_name],
                       tenant_name=config.get(config_name, 'TENANT_NAME'),
                       auth_version=config.get(config_name, 'VERSION'),
                       os_options={'tenant_id': config.get(config_name, 'TENANT_ID'),

--- a/src/load/load_file_to_objectstore.py
+++ b/src/load/load_file_to_objectstore.py
@@ -106,6 +106,8 @@ def parser():
     **Write a file to a container on the objectstore.**
 
     Use ENV:
+    Choose a PASSWORD_NAME to name the objectstore password. Add this to the config.ini file:
+    ``TENANT_PASSWORD_NAME=PASSWORD_NAME``
         ``export OBJECTSTORE_PASSWORD=**********`` to add the password to your environment before running this command script.
 
     Example commandline code:


### PR DESCRIPTION
Objectstore passwords (obviously) differ among tenants/projects. This commit handles them dynamically. Just fill in the name of the environment variable holding the password in the config.ini file.